### PR TITLE
4 digits versions for kafka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,11 @@ allprojects {
   apply plugin: 'idea'
   apply plugin: 'eclipse'
   group = "com.apache.mesos.kafka"
-  version = "0.2.6"
+  version = "1.0.8"
+}
+
+ext {
+  cliVersion = "0.2.6"
 }
 
 idea {
@@ -38,4 +42,8 @@ subprojects {
       url "https://downloads.mesosphere.com/maven/"
     }
   }
+}
+
+task cliVersion << {
+    print cliVersion
 }

--- a/cli/dcos_kafka/constants.py
+++ b/cli/dcos_kafka/constants.py
@@ -12,5 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version = '0.2.6'
+version = '0.2.5'
 """DCOS Kafka version"""

--- a/gradle/universe.gradle
+++ b/gradle/universe.gradle
@@ -14,7 +14,9 @@ task universe(dependsOn: packageVersion) {
   // incremental builds might be nice but need to research multiple inputs
   // outputs.dir "$buildDir/universe"
   doLast {
-    if( !(packageVer ==~ /^\d+\.\d+\.\d+\-\d+\.\d+\.\d+/) )
+    // supports kafka 4 digit version 0.9.0.1
+    if( !((packageVer ==~ /^\d+\.\d+\.\d+\-\d+\.\d+\.\d+/) ||
+    (packageVer ==~ /^\d+\.\d+\.\d+\-\d+\.\d+\.\d+\.\d+/)))
       throw new GradleException("Invalid Release Version: $packageVer")
 
     copy {


### PR DESCRIPTION
version of cli must be managed separate. and kakfa needs 4 digits for the version number.
switching cli back to the original version.
