### PR TITLE
added native cli descriptors

### DIFF
--- a/universe/package/resource.json
+++ b/universe/package/resource.json
@@ -11,5 +11,33 @@
     "icon-small": "https://d1vubr0evspla.cloudfront.net/img/icon-small.png",
     "icon-medium": "https://d1vubr0evspla.cloudfront.net/img/icon-medium.png",
     "icon-large": "https://d1vubr0evspla.cloudfront.net/img/icon-large.png"
+  },
+  "cli":{
+    "binaries":{
+      "darwin":{
+        "x86-64":{
+          "contentHash":[
+            {
+              "algo":"sha256",
+              "value":"{{cli-darwin-sha256}}"
+            }
+          ],
+          "kind":"executable",
+          "url":"{{artifact-dir}}/cli/darwin/dcos-kafka"
+        }
+      },
+      "linux":{
+        "x86-64":{
+          "contentHash":[
+            {
+              "algo":"sha256",
+              "value":"{{cli-linux-sha256}}"
+            }
+          ],
+          "kind":"executable",
+          "url":"{{artifact-dir}}/cli/linux/dcos-kafka"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
provides configurations for native cli.   currently both binary cli and the old cli are supported.   When cosmos and dcos is ready for native cli we will remove the command.json file.

the build process needs to supply the cli-(platform)-sha256 for each platform.

I imagine the CI environment will build just the linux platform and supply that.
