### PR TITLE
Add framework auth support for Kafka

### DIFF
--- a/kafka-scheduler/src/dist/conf/scheduler.yml
+++ b/kafka-scheduler/src/dist/conf/scheduler.yml
@@ -5,7 +5,7 @@ schedulerConfiguration:
     placementStrategy: ${PLACEMENT_STRATEGY}
     phaseStrategy: ${PHASE_STRATEGY}
     role: "${FRAMEWORK_NAME}-role"
-    principal: "${FRAMEWORK_NAME}-principal"
+    principal: ${FRAMEWORK_PRINCIPAL}
     count: ${BROKER_COUNT:-3}
 
   executor:

--- a/universe/package/config.json
+++ b/universe/package/config.json
@@ -10,6 +10,16 @@
             "type":"string",
             "default":"kafka"
           },
+          "principal": {
+            "description": "The principal for the Kafka service instance.",
+            "type": "string",
+            "default": "kafka-principal"
+          },
+          "secret_name": {
+            "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+            "type": "string",
+            "default": ""
+          },
           "placement_strategy":{
             "description":"Broker placement strategy. See documentation. [ANY, NODE]",
             "type":"string",

--- a/universe/package/marathon.json.mustache
+++ b/universe/package/marathon.json.mustache
@@ -13,6 +13,7 @@
   "env": {
     "LD_LIBRARY_PATH": "/opt/mesosphere/lib",
     "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
     "USER": "{{service.user}}",
     "PLACEMENT_STRATEGY": "{{service.placement_strategy}}",
     "PHASE_STRATEGY": "{{service.phase_strategy}}",
@@ -113,7 +114,23 @@
     "KAFKA_OVERRIDE_OFFSETS_TOPIC_SEGMENT_BYTES": "{{kafka.offsets_topic_segment_bytes}}",
     "KAFKA_OVERRIDE_LOG_CLEANER_IO_MAX_BYTES_PER_SECOND": "{{kafka.log_cleaner_io_max_bytes_per_second}}",
     "KAFKA_OVERRIDE_COMPRESSION_TYPE": "{{kafka.compression_type}}"
+    {{#service.secret_name}}
+    ,"DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "SSL_CERT_FILE": "/run/dcos/pki/tls/certs/scheduler.crt",
+    "SSL_KEY_FILE": "/run/dcos/pki/tls/private/scheduler.key",
+    "SSL_CA_FILE": "/run/dcos/pki/CA/certs/ca.crt",
+    "SSL_ENABLED": "true"
+    {{/service.secret_name}}
   },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
   "uris": [
     "{{resource.assets.uris.jre-tar-gz}}",
     "{{resource.assets.uris.scheduler-zip}}",

--- a/universe/package/resource.json
+++ b/universe/package/resource.json
@@ -9,9 +9,9 @@
     }
   },
   "images": {
-    "icon-small": "https://d1vubr0evspla.cloudfront.net/img/icon-small.png",
-    "icon-medium": "https://d1vubr0evspla.cloudfront.net/img/icon-medium.png",
-    "icon-large": "https://d1vubr0evspla.cloudfront.net/img/icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-large.png"
   },
   "cli":{
     "binaries":{


### PR DESCRIPTION
Two new options:
- User may now configure the principal (this value is important in auth)
- User may configure the name of the secret to use in auth
  This change is effectively a no-op unless the user enters something in the secret_name box.

Verified against a build of pull/1006. Fixes icon URLs while we're at it.
