### PR TITLE
Fix KAFKA_HEAP_OPTS not included in new Tasks.

### DIFF
--- a/kafka-scheduler/src/main/java/com/mesosphere/dcos/kafka/offer/PersistentOfferRequirementProvider.java
+++ b/kafka-scheduler/src/main/java/com/mesosphere/dcos/kafka/offer/PersistentOfferRequirementProvider.java
@@ -294,7 +294,6 @@ public class PersistentOfferRequirementProvider implements KafkaOfferRequirement
     String containerPath = "kafka-volume-" + UUID.randomUUID();
 
     KafkaSchedulerConfiguration config = configState.fetch(UUID.fromString(configName));
-    ServiceConfiguration serviceConfig = config.getServiceConfiguration();
     BrokerConfiguration brokerConfig = config.getBrokerConfiguration();
     ExecutorConfiguration executorConfig = config.getExecutorConfiguration();
     ZookeeperConfiguration zkConfig = config.getZookeeperConfig();
@@ -335,7 +334,8 @@ public class PersistentOfferRequirementProvider implements KafkaOfferRequirement
       .addEnvironmentVar(overridePrefix + "LOG_DIRS", containerPath + "/" + brokerName)
       .addEnvironmentVar(overridePrefix + "LISTENERS", "PLAINTEXT://:" + port)
       .addEnvironmentVar(overridePrefix + "PORT", Long.toString(port))
-      .addEnvironmentVar("KAFKA_DYNAMIC_BROKER_PORT", Boolean.toString(isDynamicPort));
+      .addEnvironmentVar("KAFKA_DYNAMIC_BROKER_PORT", Boolean.toString(isDynamicPort))
+      .addEnvironmentVar("KAFKA_HEAP_OPTS", getKafkaHeapOpts(brokerConfig.getHeap()));
 
     // Launch command for custom executor
     final String executorCommand = "./executor/bin/kafka-executor -Dlogback.configurationFile=executor/conf/logback.xml";

--- a/kafka-scheduler/src/test/java/com/mesosphere/dcos/kafka/offer/PersistentOfferRequirementProviderTest.java
+++ b/kafka-scheduler/src/test/java/com/mesosphere/dcos/kafka/offer/PersistentOfferRequirementProviderTest.java
@@ -117,8 +117,6 @@ public class PersistentOfferRequirementProviderTest {
     final CommandInfo kafkaTaskData = CommandInfo.parseFrom(taskInfo.getData());
     final Map<String, String> envFromTask = TaskUtils.fromEnvironmentToMap(kafkaTaskData.getEnvironment());
 
-    Assert.assertEquals(11, envFromTask.size());
-
     Map<String, String> expectedEnvMap = new HashMap<>();
     expectedEnvMap.put("KAFKA_ZOOKEEPER_URI", KafkaTestUtils.testKafkaZkUri);
     expectedEnvMap.put("KAFKA_OVERRIDE_ZOOKEEPER_CONNECT", KafkaTestUtils.testKafkaZkUri + "/" + KafkaTestUtils.testFrameworkName);
@@ -133,17 +131,18 @@ public class PersistentOfferRequirementProviderTest {
     expectedEnvMap.put("KAFKA_HEAP_OPTS", "-Xms500M -Xmx500M");
     expectedEnvMap.put("TASK_TYPE", KafkaTask.BROKER.name());
 
+    Assert.assertEquals(expectedEnvMap.size(), envFromTask.size());
+
     System.out.println(expectedEnvMap);
 
-    final Set<String> envVarNames = envFromTask.keySet();
-    for (String envVarName : envVarNames) {
-      Assert.assertTrue("Cannot find env key: " + envVarName, expectedEnvMap.containsKey(envVarName));
+    for (String expectedEnvKey : expectedEnvMap.keySet()) {
+      Assert.assertTrue("Cannot find env key: " + expectedEnvKey, envFromTask.containsKey(expectedEnvKey));
 
-      final String envVarValue = envFromTask.get(envVarName);
-      if ("KAFKA_OVERRIDE_LOG_DIRS".equals(envVarName)) {
+      final String envVarValue = envFromTask.get(expectedEnvKey);
+      if ("KAFKA_OVERRIDE_LOG_DIRS".equals(expectedEnvKey)) {
         Assert.assertTrue(envVarValue.contains("kafka-volume"));
         Assert.assertTrue(envVarValue.contains(KafkaTestUtils.testTaskName));
-      } else if ("KAFKA_OVERRIDE_LISTENERS".equals(envVarName)) {
+      } else if ("KAFKA_OVERRIDE_LISTENERS".equals(expectedEnvKey)) {
         Assert.assertTrue(envVarValue.contains("PLAINTEXT"));
         Assert.assertTrue(envVarValue.contains(portString));
       } else {


### PR DESCRIPTION
Also, the test wasn't validating correctly that expected environment
variables were present.

Validated manually that `ps ax` cmd line output generate by kafka-start-server.sh has the appropriate `Xms` `Xmx` values:

```
jre1.8.0_91/bin/java -Xms2048M -Xmx2048M ...
```

it used to be

```
jre1.8.0_91/bin/java -Xmx1G -Xms1G ...
```
