### PR TITLE
First cut at per-topic configuration, seeking feedback. (Enhancement) [Please review]

### DIFF
--- a/cli/dcos-kafka/main.go
+++ b/cli/dcos-kafka/main.go
@@ -157,7 +157,7 @@ type TopicHandler struct {
 	offsetsTime         string
 	partitionCount      int
 	produceMessageCount int
-	configurations      string
+	configs             string
 }
 
 func (cmd *TopicHandler) runCreate(c *kingpin.ParseContext) error {
@@ -165,8 +165,8 @@ func (cmd *TopicHandler) runCreate(c *kingpin.ParseContext) error {
 	query.Set("name", cmd.topic)
 	query.Set("partitions", strconv.FormatInt(int64(cmd.createPartitions), 10))
 	query.Set("replication", strconv.FormatInt(int64(cmd.createReplication), 10))
-	if len(cmd.configurations) > 0 {
-		query.Set("configurations", cmd.configurations)
+	if len(cmd.configs) > 0 {
+		query.Set("configs", cmd.configs)
 	}
 	cli.PrintJSON(cli.HTTPPostQuery("v1/topics", query.Encode()))
 	return nil
@@ -237,7 +237,7 @@ func handleTopicSection(app *kingpin.Application) {
 	create.Arg("topic", "The topic to create").StringVar(&cmd.topic)
 	create.Flag("partitions", "Number of partitions").Short('p').Default("1").OverrideDefaultFromEnvar("KAFKA_DEFAULT_PARTITION_COUNT").IntVar(&cmd.createPartitions)
 	create.Flag("replication", "Replication factor").Short('r').Default("3").OverrideDefaultFromEnvar("KAFKA_DEFAULT_REPLICATION_FACTOR").IntVar(&cmd.createReplication)
-	create.Flag("configurations", "Topic-level configurations k1=v1,k2=v2,...").OverrideDefaultFromEnvar("KAFKA_DEFAULT_CONFIGURATIONS").StringVar(&cmd.configurations)
+	create.Flag("configs", "Topic-level configs k1=v1,k2=v2,...").OverrideDefaultFromEnvar("KAFKA_DEFAULT_CONFIGS").StringVar(&cmd.configs)
 
 	delete := topic.Command(
 		"delete",

--- a/cli/dcos-kafka/main.go
+++ b/cli/dcos-kafka/main.go
@@ -165,7 +165,9 @@ func (cmd *TopicHandler) runCreate(c *kingpin.ParseContext) error {
 	query.Set("name", cmd.topic)
 	query.Set("partitions", strconv.FormatInt(int64(cmd.createPartitions), 10))
 	query.Set("replication", strconv.FormatInt(int64(cmd.createReplication), 10))
-	query.Set("configurations", cmd.configurations)
+	if len(cmd.configurations) > 0 {
+		query.Set("configurations", cmd.configurations)
+	}
 	cli.PrintJSON(cli.HTTPPostQuery("v1/topics", query.Encode()))
 	return nil
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -271,6 +271,21 @@ These operations mirror what is available with `bin/kafka-topics.sh`.
         "message": "Output: Created topic "topic1".n"
     }
     
+## Per-topic Configuration Overrides
+
+There is an optional `--configs` parameter to topic creation which may be set to a comma-delimited list of `key=value` pairs, overriding that topic's default configuration options as [described in the Kafka documentation][14].  Per-topic configurations can be seen in the `bin/kafka-topics.sh --describe` command.
+
+    $ dcos kafka topic create topic1 --partitions=3 --replication=3 --configs=delete.retention.ms=1111111,compression.type=lz4
+    {
+      "message": "Output: Created topic \"topic1\".\n"
+    }
+
+    $ curl -X POST -H "Authorization: token=$AUTH_TOKEN" "$DCOS_URI/v1/topics?configs=delete.retention.ms=8888888&name=topic3&partitions=1&replication=1'
+    {
+      "message":"Output: Created topic \"topic3\".\n"
+    }
+
+**TODO**: This also be supported in `describe` for output, as well as `alter topic` commands.
 
 ## View Topic Offsets
 
@@ -669,4 +684,5 @@ These operations are only applicable when `PHASE_STRATEGY` is set to `STAGE`, th
     $ curl -H "Authorization: token=$AUTH_TOKEN" "$DCOS_URI/service/kafka/v1/plan/interrupt"
     
 
+ [14]: https://kafka.apache.org/documentation/#topic-config
  [15]: https://cwiki.apache.org/confluence/display/KAFKA/System+Tools#SystemTools-GetOffsetShell

--- a/kafka-scheduler/src/main/java/com/mesosphere/dcos/kafka/cmd/CmdExecutor.java
+++ b/kafka-scheduler/src/main/java/com/mesosphere/dcos/kafka/cmd/CmdExecutor.java
@@ -32,8 +32,9 @@ public class CmdExecutor {
     this.zkPath = configuration.getFullKafkaZookeeperPath();
   }
 
-  public JSONObject createTopic(String name, int partitionCount, int replicationFactor) throws Exception {
+  public JSONObject createTopic(String name, int partitionCount, int replicationFactor, List<String> configs) throws Exception {
     // e.g. ./kafka-topics.sh --create --zookeeper master.mesos:2181/kafka-0 --topic topic0 --partitions 3 --replication-factor 3
+    //                        --config k1=v1 --config k2=v2
 
     List<String> cmd = new ArrayList<String>();
     cmd.add(binPath + "kafka-topics.sh");
@@ -46,6 +47,11 @@ public class CmdExecutor {
     cmd.add(Integer.toString(partitionCount));
     cmd.add("--replication-factor");
     cmd.add(Integer.toString(replicationFactor));
+
+    for (String conf : configs) {
+        cmd.add("--config");
+        cmd.add(conf);
+    }
 
     return runCmd(cmd);
   }

--- a/kafka-scheduler/src/main/java/com/mesosphere/dcos/kafka/web/TopicController.java
+++ b/kafka-scheduler/src/main/java/com/mesosphere/dcos/kafka/web/TopicController.java
@@ -46,7 +46,16 @@ public class TopicController {
     try {
       int partCount = Integer.parseInt(partitionCount);
       int replFactor = Integer.parseInt(replicationFactor);
-      List<String> configs = Arrays.asList(configKVCommas.split(","));
+      List<String> configs = null;
+
+      if (configKVCommas != null && configKVCommas.length() > 0) {
+          log.info("Creating topic " + name + " with configs " + configKVCommas);
+          configs = Arrays.asList(configKVCommas.split(","));
+      }
+      else {
+          log.info("Creating topic " + name + " with no configs");
+          configs = Arrays.asList();
+      }
 
       JSONObject result = cmdExecutor.createTopic(name, partCount, replFactor, configs);
       return Response.ok(result.toString(), MediaType.APPLICATION_JSON).build();

--- a/kafka-scheduler/src/main/java/com/mesosphere/dcos/kafka/web/TopicController.java
+++ b/kafka-scheduler/src/main/java/com/mesosphere/dcos/kafka/web/TopicController.java
@@ -40,12 +40,15 @@ public class TopicController {
   public Response createTopic(
       @QueryParam("name") String name,
       @QueryParam("partitions") String partitionCount,
-      @QueryParam("replication") String replicationFactor) {
+      @QueryParam("replication") String replicationFactor,
+      @QueryParam("configs") String configKVCommas) {
 
     try {
       int partCount = Integer.parseInt(partitionCount);
       int replFactor = Integer.parseInt(replicationFactor);
-      JSONObject result = cmdExecutor.createTopic(name, partCount, replFactor);
+      List<String> configs = Arrays.asList(configKVCommas.split(","));
+
+      JSONObject result = cmdExecutor.createTopic(name, partCount, replFactor, configs);
       return Response.ok(result.toString(), MediaType.APPLICATION_JSON).build();
     } catch (Exception ex) {
       log.error("Failed to create topic: " + name + " with exception: " + ex);


### PR DESCRIPTION
Proposed enhancement fixes #349 

Adds REST and CLI support for per-topic key-value configuration options in `create topic`.   Status:
* Passes existing unit tests
* TODO?  Alter topic
* TODO:  Add a feature test - how?
* TODO: Integration test