### PR TITLE
DCOS-46811: Configureable RLIMITs for RLIMIT_NOFILE

### DIFF
--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -17,6 +17,10 @@ pods:
       - {{SETUP_HELPER_URI}}
       - {{ZOOKEEPER_CLIENT_URI}}
       - {{CUSTOM_KAFKA_PRINCIPAL_URI}}
+    rlimits:
+      RLIMIT_NOFILE:
+        soft: {{RLIMITS_NOFILE_SOFT}}
+        hard: {{RLIMITS_NOFILE_HARD}}
     {{#ENABLE_VIRTUAL_NETWORK}}
     networks:
       {{VIRTUAL_NETWORK_NAME}}:

--- a/frameworks/kafka/src/main/dist/svc.yml
+++ b/frameworks/kafka/src/main/dist/svc.yml
@@ -19,8 +19,8 @@ pods:
       - {{CUSTOM_KAFKA_PRINCIPAL_URI}}
     rlimits:
       RLIMIT_NOFILE:
-        soft: {{RLIMITS_NOFILE_SOFT}}
-        hard: {{RLIMITS_NOFILE_HARD}}
+        soft: {{RLIMIT_NOFILE_SOFT}}
+        hard: {{RLIMIT_NOFILE_HARD}}
     {{#ENABLE_VIRTUAL_NETWORK}}
     networks:
       {{VIRTUAL_NETWORK_NAME}}:

--- a/frameworks/kafka/universe/config.json
+++ b/frameworks/kafka/universe/config.json
@@ -251,6 +251,30 @@
               "minimum": 10
             }
           }
+        },
+        "rlimits": {
+          "description" : "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft" : {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard" : {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
         }
       },
       "required": [

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -254,8 +254,8 @@
     "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
     "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}",
 
-    "RLIMITS_NOFILE_SOFT": "{{service.rlimits.rlimit_nofile.soft}}",
-    "RLIMITS_NOFILE_HARD": "{{service.rlimits.rlimit_nofile.hard}}"
+    "RLIMIT_NOFILE_SOFT": "{{service.rlimits.rlimit_nofile.soft}}",
+    "RLIMIT_NOFILE_HARD": "{{service.rlimits.rlimit_nofile.hard}}"
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",

--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -252,7 +252,10 @@
 
     "READINESS_CHECK_INTERVAL": "{{service.readiness_check.interval}}",
     "READINESS_CHECK_DELAY": "{{service.readiness_check.delay}}",
-    "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}"
+    "READINESS_CHECK_TIMEOUT": "{{service.readiness_check.timeout}}",
+
+    "RLIMITS_NOFILE_SOFT": "{{service.rlimits.rlimit_nofile.soft}}",
+    "RLIMITS_NOFILE_HARD": "{{service.rlimits.rlimit_nofile.hard}}"
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",


### PR DESCRIPTION
Add support for templated RLIMIT_NOFILE settings and apply elastic's defaults of 128000 descriptors.