### PR TITLE
Bumping kafka version to 1.1.1

### DIFF
--- a/frameworks/kafka/versions.sh
+++ b/frameworks/kafka/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-export TEMPLATE_KAFKA_VERSION="2.12-1.1.0"
+export TEMPLATE_KAFKA_VERSION="2.12-1.1.1"
 export TEMPLATE_DCOS_SDK_VERSION="0.55.2"


### PR DESCRIPTION
This commit bumps the kafka version to `1.1.1`, using the old-tech branch.
