### PR TITLE
add Makefile to build/install/test the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,11 @@ integration/env/
 # tools
 tools/shakedown_env
 *.pyc
+
+#build
+.stub_universe_url
+.package-options.json
+*.pem
+venv/
+logs/
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ integration/env/
 tools/shakedown_env
 *.pyc
 
-#build
+# build
 .stub_universe_url
 .package-options.json
 *.pem

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ UPLOAD_METHOD ?= aws
 # docker image that is used to build/test/install the package.
 DOCKER_IMAGE ?= mesosphere/dcos-commons
 
-# default S3_BUCKET where the stub in uploaded.
+# default S3_BUCKET where the stub is uploaded.
 S3_BUCKET ?= infinity-artifacts
 
-# default PATH where the stub url will be stored.
+# default path where the stub url will be stored.
 UNIVERSE_URL_PATH ?= .stub_universe_url
 
-# default PATH for the package options
+# default path for the package options
 PACKAGE_OPTIONS ?= .package-options.json
 
 # default DC/OS user name

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+
+# framework name of the package. The variable is also used to install package.
+FRAMEWORK_NAME ?= kafka
+
+# PATH to framework directory.
+FRAMEWORK_PATH ?= frameworks/$(FRAMEWORK_NAME)
+
+# default UPLOAD method.
+UPLOAD_METHOD ?= aws
+
+# docker image that is used to build/test/install the package.
+DOCKER_IMAGE ?= mesosphere/dcos-commons
+
+# default S3_BUCKET where the stub in uploaded.
+S3_BUCKET ?= infinity-artifacts
+
+# default PATH where the stub url will be stored.
+UNIVERSE_URL_PATH ?= .stub_universe_url
+
+# default PATH for the package options
+PACKAGE_OPTIONS ?= .package-options.json
+
+# default DC/OS user name
+DCOS_USERNAME ?= bootstrapuser
+
+# default DC/OS password
+DCOS_PASSWORD ?= deleteme
+
+# pytest version
+PY_TEST_VERSION ?= 3.10.0
+
+# max failures, used when running a single test
+PY_SINGLE_TEST_MAX_FAILURE ?= 1
+
+# default service name where the package is installed
+SERVICE_NAME ?= kafka
+
+# default service account name
+SERVICE_ACCOUNT_NAME ?= kafka-sa
+
+# default service account secret name
+SERVICE_ACCOUNT_SECRET_NAME ?= kafka-sa-secret
+
+include ./make/make.mk
+include ./make/docker.mk

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,13 @@ DCOS_PASSWORD ?= deleteme
 PY_TEST_VERSION ?= 3.10.0
 
 # max failures, used when running a single test
-PY_SINGLE_TEST_MAX_FAILURE ?= 1
+PY_SINGLE_TEST_MAX_FAILURE ?= 0
 
 # default service name where the package is installed
-SERVICE_NAME ?= kafka
+SERVICE_NAME ?= $(FRAMEWORK_NAME)
 
 # default service account name
-SERVICE_ACCOUNT_NAME ?= kafka-sa
+SERVICE_ACCOUNT_NAME ?= $(SERVICE_NAME)-sa
 
 # default service account secret name
 SERVICE_ACCOUNT_SECRET_NAME ?= kafka-sa-secret

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ SERVICE_NAME ?= $(FRAMEWORK_NAME)
 SERVICE_ACCOUNT_NAME ?= $(SERVICE_NAME)-sa
 
 # default service account secret name
-SERVICE_ACCOUNT_SECRET_NAME ?= kafka-sa-secret
+SERVICE_ACCOUNT_SECRET_NAME ?= $(SERVICE_NAME)-sa-secret
 
 include ./make/make.mk
 include ./make/docker.mk

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the source repository for the [DC/OS Apache Kafka](https://mesosphere.co
 
 ### Pre-requisites
 
-- Install the Docker, preferentially >18.09
+- Install Docker, preferentially >18.09
 
 - Setup AWS credentials. The build uses the `AWS_PROFILE` environment variable to know which AWS profile to use. Make sure to export the env variable `export AWS_PROFILE=YOUR_AWS_PROFILE` or add it to `.bashrc` or `zshrc` 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,114 @@ This is the source repository for the [DC/OS Apache Kafka](https://mesosphere.co
 
 ## Building the package
 
-In order to build a stub-universe hosted on an S3 bucket run:
+
+
+### Pre-requisites
+
+- Install the Docker, preferentially >18.09
+
+- Setup AWS credentials. The build uses the `AWS_PROFILE` environment variable to know which AWS profile to use. Make sure to export the env variable `export AWS_PROFILE=YOUR_AWS_PROFILE` or add it to `.bashrc` or `zshrc` 
+
+### Build and upload the stub to S3
+
+Make sure you have the pre-requisites installed and AWS credentials in place.
+
 ```bash
-./frameworks/kafka/build.sh aws
+make build
 ```
+
+That would launch a container, run the build and the outcome will be the stub universe url that will be saved in the file `.stub_universe_url`. That file path can be a customized running `UNIVERSE_URL_PATH=/your/custom/path make build` 	
+
+
+
+## Install the package
+
+Installing the package in a DC/OS cluster would require a DC/OS cluster being setup. As this require some set of binaries in place. The ideal way is to install the package from the container.
+
+The easiest way is entering inside the container:
+
+```
+export CLUSTER_URL=DCOS_CLUSTER_URL
+make enter-container
+make install
+```
+
+This will launch the container from where we can already install the package. The `make install` will take the stub present in `${UNIVERSE_URL_PATH}` that defaults to `.stub_universe_url`
+
+If ones wants to install a custom stub, writing the stub URL to the `.stub_universe_url` would work.
+
+`make install` takes care of a bunch of things:
+
+- detect the security mode for the DC/OS cluster, and create the service account and secret if needed.
+- generate package options to install the kafka framework.
+
+
+
+## Attach to a DC/OS cluster
+
+```
+export CLUSTER_URL=DCOS_CLUSTER_URL
+make enter-container
+make attach-dcos
+```
+
+The attach-dcos target assumes few default values like for username and password. But you can provide with different username and password
+
+```
+export CLUSTER_URL=DCOS_CLUSTER_URL
+make enter-container
+export DCOS_USERNAME=CUSTOM_USER_NAME
+export DCOS_PASSWORD=CUSTOM_PASSWORD
+make attach-dcos
+```
+
+
+
+## Running the tests
+
+In order to run the tests, we must have a DC/OS cluster available.
+
+```
+export CLUSTER_URL=DCOS_CLUSTER_URL
+make enter-container
+make test
+```
+
+When running the tests the stub present in the file `.stub_universe_url` is used.
+
+### Running tests from one file
+
+```
+make test-${test-file-name}
+```
+
+Example:
+
+```
+make test-test_sanity.py
+```
+
+### Running a single test
+
+```
+make test-${test-file-name}::${test-name}
+```
+
+Example:
+
+```
+make test-test_sanity.py::test_pod_cli
+```
+
+
+Disabling the log collection when running tests
+
+```
+export INTEGRATION_TEST_LOG_COLLECTION=false
+make test-test_sanity.py::test_pod_cli
+```
+
+
+
+Read more [here](/make/)
+

--- a/frameworks/kafka/build.gradle
+++ b/frameworks/kafka/build.gradle
@@ -37,4 +37,10 @@ distributions {
     }
 }
 
+task printDcosVersion {
+    doLast {
+        println "${project.findProperty('dcosSDKVer') ?: 'latest'}"
+    }
+}
+
 mainClassName = 'com.mesosphere.sdk.kafka.scheduler.Main'

--- a/frameworks/kafka/build.gradle
+++ b/frameworks/kafka/build.gradle
@@ -37,7 +37,7 @@ distributions {
     }
 }
 
-task printDcosVersion {
+task printSDKVersion {
     doLast {
         println "${project.findProperty('dcosSDKVer') ?: 'latest'}"
     }

--- a/make/README.md
+++ b/make/README.md
@@ -1,0 +1,34 @@
+
+
+**make enter-container**
+
+Launches the container mesosphere/dcos-commons with version present in build.gradle 
+
+**make get-container-version**
+
+prints the container version that would be launched. 
+
+```
+root@00d5a2d9bd1a:/build# make get-container-version
+mesosphere/dcos-commons:0.55.2
+```
+
+**make validate-aws-credentials**
+
+Does a head bucket operation against `S3_BUCKET` to verify if valid credentials are configrued.
+
+**make create-service-accounts**
+
+Creates the service-account and secret necessary for the package to be installed. 
+
+**make generate-package-options**
+
+Create a json file with pacakge options. As for now just configures the service account if they are needed.
+
+**make detect-security-mode**
+
+```
+root@a6b3eda7abb6:/build# make detect-security-mode
+Cluster security mode is strict
+```
+

--- a/make/README.md
+++ b/make/README.md
@@ -6,7 +6,7 @@ Launches the container mesosphere/dcos-commons with version present in build.gra
 
 **make get-container-version**
 
-prints the container version that would be launched. 
+Prints the container version that would be launched. 
 
 ```
 root@00d5a2d9bd1a:/build# make get-container-version
@@ -23,7 +23,7 @@ Creates the service-account and secret necessary for the package to be installed
 
 **make generate-package-options**
 
-Create a json file with pacakge options. As for now just configures the service account if they are needed.
+Creates a json file with pacakge options. As for now just configures the service account if they are needed.
 
 **make detect-security-mode**
 

--- a/make/create-service-account.sh
+++ b/make/create-service-account.sh
@@ -28,5 +28,5 @@ if [ "${SECURITY_MODE}" == "permissive" ]; then
 	grant_framework_permissions "${SERVICE_ACCOUNT_NAME}" nobody
 fi
 if [ "${SECURITY_MODE}" == "disabled" ]; then
-	echo "Skipping service account creation" ;
+	echo "Skipping service account creation" >&2
 fi

--- a/make/create-service-account.sh
+++ b/make/create-service-account.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Grant permissions for the framework installation
+grant_framework_permissions () {
+    SERVICE_ACCOUNT_NAME=$1
+    USER=$2
+
+    FRAMEWORK_ROLE=$(echo $SERVICE_NAME-role | sed 's/\//__/g')
+
+    dcos security org users grant $SERVICE_ACCOUNT_NAME dcos:mesos:master:framework:role:$FRAMEWORK_ROLE create
+    dcos security org users grant $SERVICE_ACCOUNT_NAME dcos:mesos:master:task:user:$USER create
+    dcos security org users grant $SERVICE_ACCOUNT_NAME dcos:mesos:agent:task:user:$USER create
+    dcos security org users grant $SERVICE_ACCOUNT_NAME dcos:mesos:master:reservation:role:$FRAMEWORK_ROLE create
+    dcos security org users grant $SERVICE_ACCOUNT_NAME dcos:mesos:master:reservation:principal:$SERVICE_NAME delete
+    dcos security org users grant $SERVICE_ACCOUNT_NAME dcos:mesos:master:volume:role:$FRAMEWORK_ROLE create
+    dcos security org users grant $SERVICE_ACCOUNT_NAME dcos:mesos:master:volume:principal:$SERVICE_NAME delete
+}
+
+
+if [ "${SECURITY_MODE}" == "strict" ]; then
+	./tools/create_service_account.sh "${SERVICE_ACCOUNT_NAME}" "${SERVICE_ACCOUNT_SECRET_NAME}" --strict --force
+	grant_framework_permissions  "${SERVICE_ACCOUNT_NAME}" nobody
+fi
+if [ "${SECURITY_MODE}" == "permissive" ]; then
+	./tools/create_service_account.sh "${SERVICE_ACCOUNT_NAME}" "${SERVICE_ACCOUNT_SECRET_NAME}"  --force
+	grant_framework_permissions "${SERVICE_ACCOUNT_NAME}" nobody
+fi
+if [ "${SECURITY_MODE}" == "disabled" ]; then
+	echo "Skipping service account creation" ;
+fi

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -1,0 +1,17 @@
+
+define run_container
+	@echo "Entering container $(DOCKER_IMAGE):$(SDK_VERSION)..."
+	docker run -i \
+		-e INSIDE_CONTAINER="true" \
+		-e S3_BUCKET=$(S3_BUCKET) \
+		-e CLUSTER_URL=$(CLUSTER_URL) \
+		-e UNIVERSE_URL_PATH=$(UNIVERSE_URL_PATH) \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-v $(PWD):/build \
+		-v $(HOME)/.gradle:/root/.gradle \
+		-v $(HOME)/.m2:/root/.m2 \
+		-v $(HOME)/.aws/credentials:/root/.aws/credentials \
+		-w /build \
+		--privileged \
+		$(2) $(DOCKER_IMAGE):$(SDK_VERSION) $(1)
+endef

--- a/make/generate-package-options.sh
+++ b/make/generate-package-options.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+
+if [ "${SECURITY_MODE}" = "disabled" ]; then
+	cat > "${PACKAGE_OPTIONS}" <<EOF
+{
+  "service": {
+    "name": "${SERVICE_NAME}"
+  }
+}
+EOF
+	exit 0
+fi
+
+
+cat > "${PACKAGE_OPTIONS}" <<EOF
+{
+  "service": {
+    "name": "${SERVICE_NAME}",
+    "service_account": "${SERVICE_ACCOUNT_NAME}",
+    "service_account_secret": "${SERVICE_ACCOUNT_SECRET_NAME}"
+  }
+}
+EOF
+

--- a/make/make.mk
+++ b/make/make.mk
@@ -33,7 +33,7 @@ endif
 
 install: export STUB_UNIVERSE_URL := $(shell cat $(UNIVERSE_URL_PATH))
 install: attach-dcos create-service-accounts generate-package-options
-	@echo "Installing the $(FRAMEWORK_NAME) package $(STUB_UNIVERSE_URL) in $(CLUSTER_URL)"
+	@echo "Installing the $(FRAMEWORK_NAME) package $(STUB_UNIVERSE_URL) in $(CLUSTER_URL)" >&2
 ifdef STUB_UNIVERSE_URL
 	$(MAKE) build
 else
@@ -60,7 +60,7 @@ generate-package-options: attach-dcos detect-security-mode
 	SERVICE_ACCOUNT_SECRET_NAME=$(SERVICE_ACCOUNT_SECRET_NAME) \
 	SECURITY_MODE=$(SECURITY_MODE) \
 	 	make/generate-package-options.sh
-	@echo "Package options generated to $(PACKAGE_OPTIONS)"
+	@echo "Package options generated to $(PACKAGE_OPTIONS)" >&2
 
 
 
@@ -84,7 +84,7 @@ test: attach-dcos
 
 test-%: export STUB_UNIVERSE_URL := $(shell cat $(UNIVERSE_URL_PATH))
 test-%: attach-dcos
-	@echo "Starting test $* ..."
+	@echo "Starting test $* ..." >&2
 	@curl -o /tmp/text_requirements.txt https://raw.githubusercontent.com/mesosphere/dcos-commons/$(SDK_VERSION)/test_requirements.txt
 	pip install pytest==$(PY_TEST_VERSION) && \
 		pip3 install -r /tmp/text_requirements.txt
@@ -100,7 +100,7 @@ endif
 detect-security-mode:
 	$(eval SECURITY_MODE := $(shell curl -X GET -s -k -H "Authorization: token=$(shell dcos config show core.dcos_acs_token)" \
 		$(shell dcos config show core.dcos_url)/dcos-metadata/bootstrap-config.json | jq .security))
-	@echo "Cluster security mode is $(SECURITY_MODE)"
+	@echo "Cluster security mode is $(SECURITY_MODE)" >&2
 
 clean-stub:
 	@rm -f $(UNIVERSE_URL_PATH)

--- a/make/make.mk
+++ b/make/make.mk
@@ -1,0 +1,113 @@
+.PHONY : install validate-aws-credentials get-security-mode
+#This makefile should not contain anything specific for a framework, like the framework name
+
+
+SDK_VERSION := $$(./gradlew  --project-dir=frameworks/$(FRAMEWORK_NAME) printDcosVersion -q)
+
+get-container-version: enter-container
+	@echo "$(DOCKER_IMAGE):$(SDK_VERSION)"
+
+# launch the container
+enter-container:
+ifndef INSIDE_CONTAINER
+	$(call run_container, /bin/bash, -t -e HOST_USER=$(shell id -un))
+endif
+
+build:
+ifndef INSIDE_CONTAINER
+	$(call run_container, /bin/bash -c "make build")
+endif
+ifdef INSIDE_CONTAINER
+	@$(MAKE) validate-aws-credentials
+	$(FRAMEWORK_PATH)/build.sh $(UPLOAD_METHOD)
+endif
+
+validate-aws-credentials:
+ifdef AWS_PROFILE
+	@aws s3api head-bucket --bucket $(S3_BUCKET) \
+	|| (echo "Cannot access $(S3_BUCKET). Make sure aws credentials are valid or aren't expired"; exit 1)
+endif
+ifndef AWS_PROFILE
+	$(error AWS_PROFILE is not defined. Consider adding it to ~/.bashrc or ~/.zshrc)
+endif
+
+install: export STUB_UNIVERSE_URL := $(shell cat $(UNIVERSE_URL_PATH))
+install: attach-dcos create-service-accounts generate-package-options
+	@echo "Installing the $(FRAMEWORK_NAME) package $(STUB_UNIVERSE_URL) in $(CLUSTER_URL)"
+ifdef STUB_UNIVERSE_URL
+	$(MAKE) build
+else
+	@dcos package repo remove $(FRAMEWORK_NAME)-$(UPLOAD_METHOD) || exit 0
+	@dcos package repo add $(FRAMEWORK_NAME)-$(UPLOAD_METHOD) --index=0 $(STUB_UNIVERSE_URL)
+	@dcos package install $(FRAMEWORK_NAME) --cli --yes
+	@dcos package install $(FRAMEWORK_NAME) --options=$(PACKAGE_OPTIONS) --yes
+	@echo "dcos $(FRAMEWORK_NAME) plan show deploy"
+endif
+
+create-service-accounts: attach-dcos detect-security-mode
+create-service-accounts:
+	@locale-gen en_US.UTF-8
+	SERVICE_NAME=$(SERVICE_NAME) \
+	SECURITY_MODE=$(SECURITY_MODE) \
+	SERVICE_ACCOUNT_NAME=$(SERVICE_ACCOUNT_NAME) \
+    SERVICE_ACCOUNT_SECRET_NAME=$(SERVICE_ACCOUNT_SECRET_NAME) \
+	make/create-service-account.sh
+
+generate-package-options: attach-dcos detect-security-mode
+	@PACKAGE_OPTIONS=$(PACKAGE_OPTIONS) \
+	SERVICE_NAME=$(SERVICE_NAME) \
+	SERVICE_ACCOUNT_NAME=$(SERVICE_ACCOUNT_NAME) \
+	SERVICE_ACCOUNT_SECRET_NAME=$(SERVICE_ACCOUNT_SECRET_NAME) \
+	SECURITY_MODE=$(SECURITY_MODE) \
+	 	make/generate-package-options.sh
+	@echo "Package options generated to $(PACKAGE_OPTIONS)"
+
+
+
+uninstall: attach-dcos
+	@dcos package uninstall $(FRAMEWORK_NAME) --yes
+
+attach-dcos: container-required
+ifdef CLUSTER_URL
+	@dcos cluster setup --no-check --username=$(DCOS_USERNAME) --password=$(DCOS_PASSWORD) $(CLUSTER_URL) || exit 0
+	@dcos task
+else
+	$(error CLUSTER_URL is not defined)
+endif
+
+test: export STUB_UNIVERSE_URL := $(shell cat $(UNIVERSE_URL_PATH))
+test: attach-dcos
+	@curl -o /tmp/text_requirements.txt https://raw.githubusercontent.com/mesosphere/dcos-commons/$(SDK_VERSION)/test_requirements.txt
+	pip install pytest==$(PY_TEST_VERSION) && \
+		pip3 install -r /tmp/text_requirements.txt
+	@py.test -vvv --capture=no $(FRAMEWORK_PATH)/tests
+
+test-%: export STUB_UNIVERSE_URL := $(shell cat $(UNIVERSE_URL_PATH))
+test-%: attach-dcos
+	@echo "Starting test $* ..."
+	@curl -o /tmp/text_requirements.txt https://raw.githubusercontent.com/mesosphere/dcos-commons/$(SDK_VERSION)/test_requirements.txt
+	pip install pytest==$(PY_TEST_VERSION) && \
+		pip3 install -r /tmp/text_requirements.txt
+	@py.test -vvv --capture=no $(FRAMEWORK_PATH)/tests/$* --maxfail=$(PY_SINGLE_TEST_MAX_FAILURE)
+
+container-required:
+ifndef INSIDE_CONTAINER
+	$(error This target should be called from inside the docker. Run 'make enter-container' first)
+endif
+
+# relies on the /dcos-metadata/bootstrap-config.json
+# detect the current attached cluster
+detect-security-mode:
+	$(eval SECURITY_MODE := $(shell curl -X GET -s -k -H "Authorization: token=$(shell dcos config show core.dcos_acs_token)" \
+		$(shell dcos config show core.dcos_url)/dcos-metadata/bootstrap-config.json | jq .security))
+	@echo "Cluster security mode is $(SECURITY_MODE)"
+
+clean-stub:
+	@rm -f $(UNIVERSE_URL_PATH)
+
+clean: clean-stub
+	rm -f $(PACKAGE_OPTIONS)
+	rm -rf $(FRAMEWORK_PATH)/build
+
+
+

--- a/make/make.mk
+++ b/make/make.mk
@@ -3,7 +3,7 @@
 
 SDK_VERSION := $$(./gradlew  --project-dir=frameworks/$(FRAMEWORK_NAME) printSDKVersion -q)
 
-RANDOM_ALPHANUMERIC := $(shell cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+RANDOM_ALPHANUMERIC := $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
 
 get-container-version: enter-container
 	@echo "$(DOCKER_IMAGE):$(SDK_VERSION)"


### PR DESCRIPTION
This PR adds the next commands to make our labor easier and onboarding a bit smooth


```
make build
make test
make install
make uninstall
```

A better documentation of this PR can be found at [here](https://github.com/mesosphere/dcos-kafka-service/tree/zain/make-build) and [here](https://github.com/mesosphere/dcos-kafka-service/blob/zain/make-build/make/README.md)