### PR TITLE
[sdk] revert to 0.55.2

### DIFF
--- a/frameworks/kafka/build.gradle
+++ b/frameworks/kafka/build.gradle
@@ -13,16 +13,13 @@ repositories {
     maven {
         url "http://downloads.mesosphere.com/maven-snapshot/"
     }
-    maven {
-        url 'http://repository.apache.org/content/repositories/snapshots/'
-    }
 }
 
 ext {
     junitVer = "4.12"
     systemRulesVer = "1.16.0"
     mockitoVer = "2.10.0"
-    dcosSDKVer = "0.56.0"
+    dcosSDKVer = "0.55.4"
 }
 
 dependencies {

--- a/frameworks/kafka/tests/test_availability.py
+++ b/frameworks/kafka/tests/test_availability.py
@@ -84,7 +84,7 @@ def test_service_startup_rapid():
     starting_time = started_time = None
     retry_seconds_remaining = max_restart_seconds + startup_padding_seconds
     while retry_seconds_remaining > 0.0 and (starting_time is None or started_time is None):
-        stdout = sdk_cmd.run_cli("task log --lines=1000 {}".format(broker_task_id_1))
+        _, stdout, _ = sdk_cmd.run_cli("task log --lines=1000 {}".format(broker_task_id_1))
         task_lines = stdout.split("\n")
         for log_line in reversed(task_lines):
             if starting_time is None and " starting (kafka.server.KafkaServer)" in log_line:

--- a/frameworks/kafka/versions.sh
+++ b/frameworks/kafka/versions.sh
@@ -13,4 +13,4 @@
 # instructions at:
 # https://wiki.mesosphere.com/display/ENGINEERING/Uploading+an+asset+to+production
 export TEMPLATE_KAFKA_VERSION="2.12-2.2.0"
-export TEMPLATE_DCOS_SDK_VERSION="0.56.0"
+export TEMPLATE_DCOS_SDK_VERSION="0.55.4"


### PR DESCRIPTION
reverting to a stable version of SDK as for 0.56.0 ` org.apache.mesos:mesos:1.8.0-SNAPSHOT` keeps disappearing.

```
> Could not resolve org.apache.mesos:mesos:1.8.0-SNAPSHOT.
[19:07:52][Step 4/5]       > Unable to load Maven meta-data from http://downloads.mesosphere.com/maven/org/apache/mesos/mesos/1.8.0-SNAPSHOT/maven-metadata.xml.
[19:07:52][Step 4/5]          > Could not get resource 'http://downloads.mesosphere.com/maven/org/apache/mesos/mesos/1.8.0-SNAPSHOT/maven-metadata.xml'.
[19:07:52][Step 4/5]             > Could not GET 'http://downloads.mesosphere.com/maven/org/apache/mesos/mesos/1.8.0-SNAPSHOT/maven-metadata.xml'. Received status code 403 from server: Forbidden
[19:07:52][Step 4/5]    > Could not resolve org.apache.mesos:mesos:1.8.0-SNAPSHOT.
[19:07:52][Step 4/5]       > Unable to load Maven meta-data from http://downloads.mesosphere.com/maven-snapshot/org/apache/mesos/mesos/1.8.0-SNAPSHOT/maven-metadata.xml.
[19:07:52][Step 4/5]          > Could not get resource 'http://downloads.mesosphere.com/maven-snapshot/org/apache/mesos/mesos/1.8.0-SNAPSHOT/maven-metadata.xml'.
[19:07:52][Step 4/5]             > Could not GET 'http://downloads.mesosphere.com/maven-snapshot/org/apache/mesos/mesos/1.8.0-SNAPSHOT/maven-metadata.xml'. Received status code 403 from server: Forbidden
[19:07:52][Step 4/5] > Could not resolve org.apache.mesos:mesos:1.8.0-SNAPSHOT.
```